### PR TITLE
Srt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ This uses the built in captions support of Twitch's video player so viewers only
 Viewers can use the [FrankerFaceZ Browser extension](https://chrome.google.com/webstore/detail/frankerfacez/fadndhdgpmmaapbmfcknlfgcflmmmieb) which provides the ability to set fully custom caption box positions and more settings.
 
 Captions for local recordings currently aren't too useful. They only work with certain file formats (ts, mp4, mov) and only very few video players can correctly play them.
-MPV can play them normally with .ts files, almost no common video players play them in mp4 and mov files.  
+MPV can play them normally with .ts files, almost no common video players play them in mp4 and mov files. For local recordings, storing subtitles as transcript in SubRip (SRT)
+format might be more useful: there are many tools available for post-editing subtitles in SRT format as well as for re-encoding them into various video formats.
 
 ### Installation (Windows):
 #### Requires OBS 23.2.1 (released June 15th 2019) or newer!

--- a/lib/caption_stream/CaptionResult.h
+++ b/lib/caption_stream/CaptionResult.h
@@ -28,6 +28,7 @@ struct CaptionResult {
     string caption_text;
     string raw_message;
 
+    std::chrono::steady_clock::time_point start_at;
     std::chrono::steady_clock::time_point created_at;
 
     CaptionResult(){};
@@ -37,13 +38,15 @@ struct CaptionResult {
             bool final,
             double stability,
             string caption_text,
-            string raw_message
-    ) :
+            string raw_message,
+            std::chrono::steady_clock::time_point start_at
+   ) :
             index(index),
             final(final),
             stability(stability),
             caption_text(caption_text),
             raw_message(raw_message),
+            start_at(start_at),
             created_at(std::chrono::steady_clock::now()) {
     }
 };

--- a/src/SourceCaptioner.cpp
+++ b/src/SourceCaptioner.cpp
@@ -355,7 +355,7 @@ void SourceCaptioner::clear_output_timer_cb() {
 
     }
 
-    auto clearance = CaptionOutput(std::make_shared<OutputCaptionResult>(CaptionResult(0, false, 0, "", "")), false, true);
+    auto clearance = CaptionOutput(std::make_shared<OutputCaptionResult>(CaptionResult(0, false, 0, "", "", std::chrono::steady_clock::now())), false, true);
     output_caption_writers(clearance,
                            to_stream,
                            to_transcript_streaming,
@@ -553,8 +553,7 @@ void SourceCaptioner::stream_started_event() {
         auto control_transcript = std::make_shared<CaptionOutputControl<TranscriptOutputSettings>>(cur_settings.transcript_settings);
         transcript_streaming_output.set_control(control_transcript);
 
-        bool raw = cur_settings.transcript_settings.format == "raw";
-        std::thread th2(transcript_writer_loop, control_transcript, true, raw);
+        std::thread th2(transcript_writer_loop, control_transcript, true, cur_settings.transcript_settings.format);
         th2.detach();
     }
 }
@@ -578,8 +577,7 @@ void SourceCaptioner::recording_started_event() {
         auto control_transcript = std::make_shared<CaptionOutputControl<TranscriptOutputSettings>>(cur_settings.transcript_settings);
         transcript_recording_output.set_control(control_transcript);
 
-        bool raw = cur_settings.transcript_settings.format == "raw";
-        std::thread th2(transcript_writer_loop, control_transcript, false, raw);
+        std::thread th2(transcript_writer_loop, control_transcript, false, cur_settings.transcript_settings.format);
         th2.detach();
     }
 }

--- a/src/caption_stream_helper.cpp
+++ b/src/caption_stream_helper.cpp
@@ -485,8 +485,8 @@ static void setup_combobox_transcript_format(QComboBox &comboBox) {
         comboBox.removeItem(0);
 
     comboBox.addItem("Basic Text", "txt");
+    comboBox.addItem("SubRip (SRT) ", "srt");
     comboBox.addItem("Raw (For Debug/Tools, Very Spammy)", "raw");
-//    comboBox.addItem("SRT ", "srt");
 }
 
 


### PR DESCRIPTION
Hi,
I implemented rudimentary support for transcripts in SubRip (SRT) format. Please have a look. For me, it makes the OBS Caption Plugin much more useful for local recordings, as the SRT format allows for easy post-editing (correcting subtitles) and using tools such as Handbreak allow to properly add the subtitles to various video formats in such a way that many players support them. 

Best,
Achim

PS: The "heuristic" for the the start time for captions is rather ad hoc but seems to work "well enough" in my tests - for sure, there is a lot of room for improvement. 