### PR TITLE
Fix typo in characters, fix typo in length name/references

### DIFF
--- a/src/ui/CaptionSettingsWidget.cpp
+++ b/src/ui/CaptionSettingsWidget.cpp
@@ -488,7 +488,7 @@ void CaptionSettingsWidget::accept_current_settings() {
     transcript_settings.output_path = transcriptFolderPathLineEdit->text().toStdString();
     transcript_settings.format = transcriptFormatComboBox->currentData().toString().toStdString();
     transcript_settings.srt_target_duration_secs = srtDurationSpinBox->value();
-    transcript_settings.srt_target_line_length = srtLineLenghtSpinBox->value();
+    transcript_settings.srt_target_line_length = srtLineLengthSpinBox->value();
 
     transcript_settings.recording_filename_type = recordingTranscriptFilenameComboBox->currentData().toString().toStdString();
     transcript_settings.recording_filename_custom = recordingTranscriptCustomNameOverwriteLineEdit->text().toStdString();
@@ -556,7 +556,7 @@ void CaptionSettingsWidget::updateUi() {
     combobox_set_data_str(*transcriptFormatComboBox, source_settings.transcript_settings.format.c_str(), 0);
     transcript_format_index_change(0);
     srtDurationSpinBox->setValue(source_settings.transcript_settings.srt_target_duration_secs);
-    srtLineLenghtSpinBox->setValue(source_settings.transcript_settings.srt_target_line_length);
+    srtLineLengthSpinBox->setValue(source_settings.transcript_settings.srt_target_line_length);
 
     combobox_set_data_str(*recordingTranscriptFilenameComboBox, source_settings.transcript_settings.recording_filename_type.c_str(), 0);
     combobox_set_data_str(*recordingTranscriptCustomNameExistsCombobox,

--- a/src/ui/CaptionSettingsWidget.ui
+++ b/src/ui/CaptionSettingsWidget.ui
@@ -915,9 +915,9 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QSpinBox" name="srtLineLenghtSpinBox">
+           <widget class="QSpinBox" name="srtLineLengthSpinBox">
             <property name="suffix">
-             <string>  charachters</string>
+             <string> characters</string>
             </property>
             <property name="minimum">
              <number>10</number>


### PR DESCRIPTION
This makes two main changes in the Caption Settings Widget:

- Fixes the typo in "characters" in the settings (Transcripts -> Max Caption Line Length), and
- Renames the "srtLineLenghtSpinBox" widget name to "srtLineLengthSpinBox" (and updating where it's referred to as the old name)