### PR TITLE
Indicate in dock that a source wasn't selected

### DIFF
--- a/src/ui/CaptionDock.cpp
+++ b/src/ui/CaptionDock.cpp
@@ -52,6 +52,13 @@ void CaptionDock::handle_source_capture_status_change(shared_ptr<SourceCaptioner
             status_text);
 
     this->statusTextLabel->setText(QString::fromStdString(status_text));
+    if (status->settings.scene_collection_settings.caption_source_settings.caption_source_name.empty())	{
+        this->captionLinesPlainTextEdit->setStyleSheet("background-color: salmon; font-weight: bold;");
+        this->captionLinesPlainTextEdit->setPlainText("No source selected! Nothing to caption.");
+    } else {
+        this->captionLinesPlainTextEdit->setStyleSheet("background-color: white; font-weight: normal;");
+        this->captionLinesPlainTextEdit->clear();
+	}
 }
 
 void CaptionDock::handle_caption_data_cb(

--- a/src/ui/uiutils.h
+++ b/src/ui/uiutils.h
@@ -136,6 +136,9 @@ static bool captioning_status_string(
     if (!enabled) {
         output = "CC Disabled";
     } else {
+        const string source_name = corrected_streaming_audio_output_capture_source_name(
+            status.settings.scene_collection_settings.caption_source_settings.caption_source_name);
+
         if (status.event_type == SOURCE_CAPTIONER_STATUS_EVENT_STOPPED
             || status.event_type == SOURCE_CAPTIONER_STATUS_EVENT_NEW_SETTINGS_STOPPED) {
             if (streaming_output_enabled && recording_output_enabled)
@@ -148,12 +151,13 @@ static bool captioning_status_string(
                 output = "Offline";
 
         } else if (status.event_type == SOURCE_CAPTIONER_STATUS_EVENT_STARTED_ERROR) {
-            output = "Off";
+            if (source_name.empty())
+                output = "Source not selected!";
+            else
+                output = "Off";
         } else if (status.event_type == SOURCE_CAPTIONER_STATUS_EVENT_STARTED_OK
                    || status.event_type == SOURCE_CAPTIONER_STATUS_EVENT_AUDIO_CAPTURE_STATUS_CHANGE) {
 
-            const string source_name = corrected_streaming_audio_output_capture_source_name(
-                    status.settings.scene_collection_settings.caption_source_settings.caption_source_name);
             const string mute_source_name = status.settings.scene_collection_settings.caption_source_settings.active_mute_source_name();
 
             const string source_name_use = "(" + source_name + ")";


### PR DESCRIPTION
This turns the caption text area read with an warning that hopefully will get the streamer's attention so they know they're not captioning anything because they haven't selected a source.

Addresses issue #133 .