### PR TITLE
Add human strings for plugin manager

### DIFF
--- a/src/google_s2t_caption_plugin.cpp
+++ b/src/google_s2t_caption_plugin.cpp
@@ -40,7 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using namespace std;
 
-//SourceCaptioner *captioner_instance = nullptr;
+// SourceCaptioner *captioner_instance = nullptr;
 MainCaptionWidget *main_caption_widget = nullptr;
 CaptionPluginManager *plugin_manager = nullptr;
 
@@ -50,8 +50,7 @@ bool ui_setup_done = false;
 
 OBS_DECLARE_MODULE()
 
-
-//OBS_MODULE_USE_DEFAULT_LOCALE("my-plugin", "en-US")
+// OBS_MODULE_USE_DEFAULT_LOCALE("my-plugin", "en-US")
 void finished_loading_event();
 
 void stream_started_event();
@@ -74,46 +73,67 @@ void obs_frontent_exiting();
 
 void obs_frontent_scene_collection_changed();
 
-static void obs_event(enum obs_frontend_event event, void *) {
-//    debug_log("obs_event %d", (int) std::hash<std::thread::id>{}(std::this_thread::get_id()));
-//    int tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
-//    info_log("obs event %d", tid);
-    if (event == OBS_FRONTEND_EVENT_FINISHED_LOADING) {
+static void obs_event(enum obs_frontend_event event, void *)
+{
+    //    debug_log("obs_event %d", (int) std::hash<std::thread::id>{}(std::this_thread::get_id()));
+    //    int tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
+    //    info_log("obs event %d", tid);
+    if (event == OBS_FRONTEND_EVENT_FINISHED_LOADING)
+    {
         finished_loading_event();
-    } else if (event == OBS_FRONTEND_EVENT_STREAMING_STARTED) {
+    }
+    else if (event == OBS_FRONTEND_EVENT_STREAMING_STARTED)
+    {
         stream_started_event();
-    } else if (event == OBS_FRONTEND_EVENT_STREAMING_STOPPED) {
+    }
+    else if (event == OBS_FRONTEND_EVENT_STREAMING_STOPPED)
+    {
         stream_stopped_event();
-    } else if (event == OBS_FRONTEND_EVENT_RECORDING_STARTED) {
+    }
+    else if (event == OBS_FRONTEND_EVENT_RECORDING_STARTED)
+    {
         recording_started_event();
-    } else if (event == OBS_FRONTEND_EVENT_RECORDING_STOPPED) {
+    }
+    else if (event == OBS_FRONTEND_EVENT_RECORDING_STOPPED)
+    {
         recording_stopped_event();
-    } else if (event == OBS_FRONTEND_EVENT_VIRTUALCAM_STARTED) {
+    }
+    else if (event == OBS_FRONTEND_EVENT_VIRTUALCAM_STARTED)
+    {
         virtualcam_started_event();
-    } else if (event == OBS_FRONTEND_EVENT_VIRTUALCAM_STOPPED) {
+    }
+    else if (event == OBS_FRONTEND_EVENT_VIRTUALCAM_STOPPED)
+    {
         virtualcam_stopped_event();
-    } else if (event == OBS_FRONTEND_EVENT_EXIT) {
+    }
+    else if (event == OBS_FRONTEND_EVENT_EXIT)
+    {
         obs_frontent_exiting();
-    } else if (event == OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED) {
+    }
+    else if (event == OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED)
+    {
         obs_frontent_scene_collection_changed();
-    } else if (event == OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED) {
+    }
+    else if (event == OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED)
+    {
         printf("studio mode!!!!!!!!!!!!!!!!!!!!\n");
-
     }
 }
 
-
-void closed_caption_tool_menu_clicked() {
+void closed_caption_tool_menu_clicked()
+{
     debug_log("caption menu button clicked ");
-//    int tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
-//    info_log("test clicked %d", tid);
+    //    int tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
+    //    info_log("test clicked %d", tid);
 
-    if (main_caption_widget) {
+    if (main_caption_widget)
+    {
         main_caption_widget->show_self();
     }
 }
 
-void setup_dock() {
+void setup_dock()
+{
     debug_log("setup_dock()");
     if (caption_dock || !plugin_manager || !main_caption_widget)
         return;
@@ -124,12 +144,13 @@ void setup_dock() {
     obs_frontend_add_dock_by_id("cloud_closed_captions_dock_main", "Captions", caption_dock);
 }
 
-void setup_UI() {
+void setup_UI()
+{
     if (ui_setup_done)
         return;
 
     debug_log("setup_UI()");
-    QAction *action = (QAction *) obs_frontend_add_tools_menu_qaction("Cloud Closed Captions");
+    QAction *action = (QAction *)obs_frontend_add_tools_menu_qaction("Cloud Closed Captions");
     action->connect(action, &QAction::triggered, &closed_caption_tool_menu_clicked);
 
     setup_dock();
@@ -137,8 +158,9 @@ void setup_UI() {
     ui_setup_done = true;
 }
 
-void finished_loading_event() {
-#if  defined(__linux__)
+void finished_loading_event()
+{
+#if defined(__linux__)
     auto hmm = obs_output_output_caption_text2;
 #endif
 
@@ -146,7 +168,8 @@ void finished_loading_event() {
 
     info_log("OBS_FRONTEND_EVENT_FINISHED_LOADING, plugin_manager loaded: %d, %s",
              plugin_manager != nullptr, qVersion());
-    if (main_caption_widget) {
+    if (main_caption_widget)
+    {
         main_caption_widget->external_state_changed();
 #ifdef USE_DEVMODE
         main_caption_widget->show();
@@ -155,59 +178,69 @@ void finished_loading_event() {
     }
 }
 
-void stream_started_event() {
+void stream_started_event()
+{
     info_log("stream_started_event");
     if (main_caption_widget)
         main_caption_widget->stream_started_event();
 }
 
-void stream_stopped_event() {
+void stream_stopped_event()
+{
     info_log("stream_stopped_event");
     if (main_caption_widget)
         main_caption_widget->stream_stopped_event();
 }
 
-void recording_started_event() {
+void recording_started_event()
+{
     info_log("recording_started_event");
     if (main_caption_widget)
         main_caption_widget->recording_started_event();
 }
 
-void virtualcam_started_event() {
+void virtualcam_started_event()
+{
     if (main_caption_widget)
         main_caption_widget->virtualcam_started_event();
 }
-void virtualcam_stopped_event() {
+void virtualcam_stopped_event()
+{
     if (main_caption_widget)
         main_caption_widget->virtualcam_stopped_event();
 }
 
-void recording_stopped_event() {
+void recording_stopped_event()
+{
     info_log("recording_stopped_event");
     if (main_caption_widget)
         main_caption_widget->recording_stopped_event();
 }
 
-void obs_frontent_scene_collection_changed() {
+void obs_frontent_scene_collection_changed()
+{
     info_log("obs_frontent_scene_collection_changed");
 
-    if (main_caption_widget) {
+    if (main_caption_widget)
+    {
         main_caption_widget->scene_collection_changed();
     }
-
 }
 
-void obs_frontent_exiting() {
+void obs_frontent_exiting()
+{
     info_log("obs_frontent_exiting, stopping captioner");
 
-    if (main_caption_widget) {
-//        main_caption_widget->stop();
+    if (main_caption_widget)
+    {
+        //        main_caption_widget->stop();
         delete main_caption_widget;
         main_caption_widget = nullptr;
     }
 
-    if (plugin_manager) {
-//        save_CaptionPluginSettings_to_config(plugin_manager->plugin_settings);
+    if (plugin_manager)
+    {
+        //        save_CaptionPluginSettings_to_config(plugin_manager->plugin_settings);
 
         delete plugin_manager;
         plugin_manager = nullptr;
@@ -215,56 +248,62 @@ void obs_frontent_exiting() {
     info_log("obs_frontent_exiting done");
 }
 
-//static void save_or_load_event_callback_config(obs_data_t *_, bool saving, void *) {
-//    int tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
-//    info_log("google_s2t_caption_plugin save_or_load_event_callback %d, %d", saving, tid);
+// static void save_or_load_event_callback_config(obs_data_t *_, bool saving, void *) {
+//     int tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
+//     info_log("google_s2t_caption_plugin save_or_load_event_callback %d, %d", saving, tid);
 //
-//    if (saving) {
-//        // always save too when main OBS saves
-//        if (plugin_manager) {
-//            save_CaptionPluginSettings_to_config(plugin_manager->plugin_settings);
-//        }
-//    } else {
-//        if (!plugin_manager && !main_caption_widget) {
-//            info_log("google_s2t_caption_plugin initial load");
-//            CaptionPluginSettings settings = load_CaptionPluginSettings_from_config();
+//     if (saving) {
+//         // always save too when main OBS saves
+//         if (plugin_manager) {
+//             save_CaptionPluginSettings_to_config(plugin_manager->plugin_settings);
+//         }
+//     } else {
+//         if (!plugin_manager && !main_caption_widget) {
+//             info_log("google_s2t_caption_plugin initial load");
+//             CaptionPluginSettings settings = load_CaptionPluginSettings_from_config();
 //
-//            plugin_manager = new CaptionPluginManager(settings);
-//            main_caption_widget = new MainCaptionWidget(*plugin_manager);
-//            setup_UI();
-//        }
-//    }
-//}
+//             plugin_manager = new CaptionPluginManager(settings);
+//             main_caption_widget = new MainCaptionWidget(*plugin_manager);
+//             setup_UI();
+//         }
+//     }
+// }
 
-
-static void save_or_load_event_callback(obs_data_t *save_data, bool saving, void *) {
+static void save_or_load_event_callback(obs_data_t *save_data, bool saving, void *)
+{
     int tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
     info_log("save_or_load_event_callback %d, %d", saving, tid);
 
-    if (saving && plugin_manager) {
+    if (saving && plugin_manager)
+    {
         save_CaptionPluginSettings(save_data, plugin_manager->plugin_settings);
     }
 
-    if (!saving) {
+    if (!saving)
+    {
         auto loaded_settings = load_CaptionPluginSettings(save_data);
-        if (plugin_manager && main_caption_widget) {
+        if (plugin_manager && main_caption_widget)
+        {
             plugin_manager->update_settings(loaded_settings);
-        } else if (plugin_manager || main_caption_widget) {
+        }
+        else if (plugin_manager || main_caption_widget)
+        {
             error_log("only one of plugin_manager and main_caption_widget, wtf, %d %d",
                       plugin_manager != nullptr, main_caption_widget != nullptr);
-        } else {
+        }
+        else
+        {
             plugin_manager = new CaptionPluginManager(loaded_settings);
             main_caption_widget = new MainCaptionWidget(*plugin_manager);
             setup_UI();
         }
     }
-
 }
 
-
-bool obs_module_load(void) {
+bool obs_module_load(void)
+{
     info_log("google_s2t_caption_plugin %s obs_module_load %d", VERSION_STRING,
-             (int) std::hash<std::thread::id>{}(std::this_thread::get_id()));
+             (int)std::hash<std::thread::id>{}(std::this_thread::get_id()));
     qRegisterMetaType<std::string>();
     qRegisterMetaType<shared_ptr<OutputCaptionResult>>();
     qRegisterMetaType<CaptionResult>();
@@ -275,10 +314,22 @@ bool obs_module_load(void) {
     return true;
 }
 
-void obs_module_post_load(void) {
+void obs_module_post_load(void)
+{
     info_log("google_s2t_caption_plugin %s obs_module_post_load", VERSION_STRING);
 }
 
-void obs_module_unload(void) {
+void obs_module_unload(void)
+{
     info_log("google_s2t_caption_plugin %s obs_module_unload", VERSION_STRING);
+}
+
+MODULE_EXPORT const char *obs_module_description(void)
+{
+    return obs_module_text("Provides closed captioning via Google Cloud Speech Recognition API");
+}
+
+MODULE_EXPORT const char *obs_module_name(void)
+{
+    return obs_module_text("Cloud Closed Captions");
 }


### PR DESCRIPTION
This (should) convert the name from the code-y name to a human name

<img width="874" height="441" alt="image" src="https://github.com/user-attachments/assets/8d0cbffc-e6a4-4e2d-b678-6e19d0eb52df" />

I borrowed from for how to:

https://github.com/FiniteSingularity/obs-quick-access-utility/blob/ac7bb71519702621d98ccc8ebc53559e73c48d9f/src/plugin-module.c#L41
https://github.com/exeldro/obs-move-transition/blob/1cc2cd7989b89c239db2d3b0f7006f208e5def0f/move-transition.c#L3358

I couldn't get the plugin to build here to check my code (either on windows or mac) to test, but thats a whole different issue)